### PR TITLE
Run Test in Internet Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ On each worker/node machine:
 4. Download the latest version of [Selenium Standalone Server](http://www.seleniumhq.org/download) and save it to `C:\Selenium` on each machine.
 5. Download the latest version of [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver/downloads) and save it to `C:\Selenium` on each machine.
 6. Download the latest version of [Geckodriver](https://github.com/mozilla/geckodriver/releases) and save it to `C:\Selenium` on each machine.
-7. Copy the [NODE_Config.json](selenium/NODE_Config.json) file and save it to `C:\Selenium` on each machine.
-8. Run the following command: `npm run node`.
+7. Download the latest version of [InternetExplorerDriver](http://www.seleniumhq.org/download/) and save it to `C:\Selenium` on each machine.
+   - Go to the `The Internet Explorer Driver Server` section and download either the 32 bit or 64 bit version, depending on the machine.
+8. Copy the [NODE_Config.json](selenium/NODE_Config.json) file and save it to `C:\Selenium` on each machine.
+9. Run the following command: `npm run node`.
    - Or you can also run the `NODE_SeleniumGrid.bat` file included in this repo in the `selenium` folder.
    - If the [Hub](#starting-the-selenium-hub) is running on a different machine, open the `NODE_Config.json` file and update the address for the Hub.
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,5 +10,5 @@
 - [ ] Clean up WebElementExtensions.cs
 - [x] Look into using Docker to create the Selenium Grid
 - [ ] Add a config setting to allow for retries if a test fails, and set a limit on how many times to retry.
-- [ ] Look into having the option to run tests on multiple browsers.
+- [x] Look into having the option to run tests on multiple browsers.
 - [ ] Clean up the root directory.

--- a/src/Automation.Selenium/Automation.Selenium.csproj
+++ b/src/Automation.Selenium/Automation.Selenium.csproj
@@ -46,7 +46,8 @@
     <Compile Include="RunSelenium.cs" />
     <Compile Include="SeleniumRegistry.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Utils\TestSettingsReader.cs" />
+    <Compile Include="TestSettingsReader.cs" />
+    <Compile Include="Utils\OperatingSystemType.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Choose>

--- a/src/Automation.Selenium/TestSettingsReader.cs
+++ b/src/Automation.Selenium/TestSettingsReader.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Configuration;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Remote;
-using static System.Configuration.ConfigurationManager;
+using Automation.Selenium.Utils;
 
-namespace Automation.Selenium.Utils
+namespace Automation.Selenium
 {
     internal class TestSettingsReader
     {
@@ -12,13 +13,18 @@ namespace Automation.Selenium.Utils
             get
             {
                 BrowserType targetBrowser;
-                Enum.TryParse(AppSettings["targetBrowser"], out targetBrowser);
+                Enum.TryParse(ConfigurationManager.AppSettings["targetBrowser"], out targetBrowser);
 
-                // ReSharper disable once SwitchStatementMissingSomeCases
                 switch (targetBrowser)
                 {
+                    case BrowserType.Chrome:
+                        return DesiredCapabilities.Chrome();
+                    case BrowserType.Ie:
+                        return DesiredCapabilities.InternetExplorer();
                     case BrowserType.Firefox:
                         return DesiredCapabilities.Firefox();
+                    case BrowserType.Safari:
+                        return DesiredCapabilities.Safari();
                     default:
                         return DesiredCapabilities.Chrome();
                 }
@@ -29,14 +35,19 @@ namespace Automation.Selenium.Utils
         {
             get
             {
-                var operatingSystem = AppSettings["operatingSystem"];
+                OperatingSystemType operatingSystem;
+                Enum.TryParse(ConfigurationManager.AppSettings["operatingSystem"], out operatingSystem);
 
                 switch (operatingSystem)
                 {
-                    case "Any":
+                    case OperatingSystemType.Any:
                         return new Platform(PlatformType.Any);
-                    case "Mac":
+                    case OperatingSystemType.Linux:
+                        return new Platform(PlatformType.Linux);
+                    case OperatingSystemType.Mac:
                         return new Platform(PlatformType.Mac);
+                    case OperatingSystemType.Windows:
+                        return new Platform(PlatformType.Windows);
                     default:
                         return new Platform(PlatformType.Windows);
                 }
@@ -47,7 +58,7 @@ namespace Automation.Selenium.Utils
         {
             get
             {
-                var uri = AppSettings["seleniumHubUri"];
+                var uri = ConfigurationManager.AppSettings["seleniumHubUri"];
 
                 return string.IsNullOrWhiteSpace(uri) ? new Uri("http://localhost:4444/wd/hub") : new Uri(uri);
             }
@@ -57,9 +68,9 @@ namespace Automation.Selenium.Utils
         {
             get
             {
-                var directory = AppSettings["screenshotFolder"];
+                var directory = ConfigurationManager.AppSettings["screenshotFolder"];
 
-                return directory ?? "C:\\UI_Test_Screenshots\\";
+                return string.IsNullOrWhiteSpace(directory) ? "C:\\UI_Test_Screenshots\\" : directory;
             }
         }
     }

--- a/src/Automation.Selenium/Utils/BrowserType.cs
+++ b/src/Automation.Selenium/Utils/BrowserType.cs
@@ -3,6 +3,8 @@
     public enum BrowserType
     {
         Chrome,
-        Firefox
+        Ie,
+        Firefox,
+        Safari
     }
 }

--- a/src/Automation.Selenium/Utils/OperatingSystemType.cs
+++ b/src/Automation.Selenium/Utils/OperatingSystemType.cs
@@ -1,0 +1,10 @@
+﻿namespace Automation.Selenium.Utils
+{
+    public enum OperatingSystemType
+    {
+        Any,
+        Linux,
+        Mac,
+        Windows
+    }
+}

--- a/src/Automation.Tests/App.config
+++ b/src/Automation.Tests/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <appSettings>
-        <add key="targetBrowser" value="Firefox"/>
+        <add key="targetBrowser" value="Ie"/>
         <add key="operatingSystem" value="Any"/>
         <add key="seleniumHubUri" value="http://localhost:4444/wd/hub"/>
         <add key="screenshotFolder" value="C:\UI_Test_Screenshots\"/>


### PR DESCRIPTION
Most of the work for this had already been done in pull request #6 when I added the nodeConfig.json file.

In this branch I mainly updated the documentation and updated the TestSettingsReader class to use it.